### PR TITLE
fix compilation error on GHC-7.10

### DIFF
--- a/src/Proper/Utils.hs
+++ b/src/Proper/Utils.hs
@@ -2,12 +2,22 @@ module Proper.Utils(
   Name,
   Error(..), extractValue) where
 
+import Control.Applicative
+import Control.Monad
+
 type Name = String
 
 data Error a =
   Succeeded a |
   Failed String
   deriving (Show)
+
+instance Functor Error where
+  fmap = liftM
+
+instance Applicative Error where
+  pure = return
+  (<*>) = ap
 
 instance Monad Error where
   return a = Succeeded a


### PR DESCRIPTION
This fix compilation error on GHC-7.10 due to the Functor-Applicative-Monad Proposal.
